### PR TITLE
fix syntax error on py 3.6

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -20,7 +20,7 @@ from analytics.utils import import_string
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution('analytics').version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'
 
 


### PR DESCRIPTION
For py 3.6+

`except` with a named variable should come with `as`.